### PR TITLE
Generate utf-8 wralea files

### DIFF
--- a/src/openalea/core/package.py
+++ b/src/openalea/core/package.py
@@ -724,6 +724,7 @@ class PyPackageWriter(object):
     """ Write a wralea python file """
 
     wralea_template = """
+# -*- coding: utf-8 -*-
 # This file has been generated at $TIME
 
 from openalea.core import *

--- a/src/openalea/core/package.py
+++ b/src/openalea/core/package.py
@@ -724,7 +724,7 @@ class PyPackageWriter(object):
     """ Write a wralea python file """
 
     wralea_template = """
-# -*- coding: utf-8 -*-
+# -*- coding: latin-1 -*-
 # This file has been generated at $TIME
 
 from openalea.core import *


### PR DESCRIPTION
Some comments or author names may content non-classical characters.
Add utf-8 header in wralea files