### PR TITLE
Restore version 

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,8 +1,10 @@
 {% set pyproject = load_file_data('../pyproject.toml', from_recipe_dir=True) %}
+{% set name = pyproject.get('project').get('name') %}
+{% set version = GIT_DESCRIBE_TAG | replace("v", "") %}
 
 package:
-  name: {{ pyproject["project"]["name"] }}
-  version: {{ GIT_DESCRIBE_TAG  | replace("v", "") }}
+  name: {{ name }}
+  version: {{ version }}
 
 source:
   path: ..

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
 ]
 
 [tool.setuptools.dynamic]
-version = {attr = "openalea.core.version.__version__"}
 readme = {file = ["README.md"]}
 
 # section specific to conda-only distributed package (not used by pip yet)

--- a/src/openalea/core/version.py
+++ b/src/openalea/core/version.py
@@ -1,19 +1,3 @@
-#import importlib.metadata
+import importlib.metadata
 
-#__version__ =  importlib.metadata.version("openalea.core")
-
-#numbers = __version__.split(".")
-
-"""
-try:
-    major, minor, post = numbers[0], numbers[1], numbers[2]
-    patch = '.'.join(numbers[3:])
-except IndexError:
-    major, minor, post = '2', '4', '3'
-    patch = '0'
-    __version__ = '.'.join([major, minor, post])
-"""
-
-major, minor, post = '2', '4', '3'
-patch = 'a1'
-__version__ = '.'.join([major, minor, post, patch])
+__version__ =  importlib.metadata.version("openalea.core")


### PR DESCRIPTION
Restore version managed by setuptools_scm
However, there is a bug in the action.
When the CI run in a branch, the git tag is set to dev